### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/luacov-console-1.1.0-1.rockspec
+++ b/luacov-console-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "luacov-console"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/spacewander/luacov-console",
+    url = "git+https://github.com/spacewander/luacov-console",
     tag = "1.1",
 }
 description = {

--- a/luacov-console-scm-0.rockspec
+++ b/luacov-console-scm-0.rockspec
@@ -1,7 +1,7 @@
 package = "luacov-console"
 version = "scm-0"
 source = {
-    url = "git://github.com/spacewander/luacov-console",
+    url = "git+https://github.com/spacewander/luacov-console",
     branch = "master",
 }
 description = {


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/