### PR TITLE
adding support for patterns in summary report

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Luacov-console is a luacov reporter makes it easier for your development cycle a
     Unlike luacov, luacov-console also counts lua files under `workdir` which weren't touched by tests.
 3. Run `luacov-console -s` to see the summary of coverage results.
 4. Run `luacov-console -l [lua pattern1] [lua pattern2]` to see the report of matched files.
+5. Run `luacov-console -s -l [lua pattern1] [lua pattern2]` to see the summary only for matched files.
 
 ## Installation
 

--- a/src/luacov-console.lua
+++ b/src/luacov-console.lua
@@ -28,6 +28,10 @@ local function colored_print(color, text)
 end
 
 local function colored_print_if_pattern(color, text, patterns)
+    if not patterns or #patterns == 0 then
+        colored_print(color, text)
+        return
+    end
     for _, pattern in ipairs(patterns) do
         if text:match(pattern) then
             colored_print(color, text)
@@ -52,7 +56,7 @@ local function index()
         print_error("Can't stat ctime of ", report_file_ctime, ": ", err)
     end
     if report_file_ctime > idx_file_ctime then
-        print_error(report_file, " was changed after ", idx_file, " created."..
+        print_error(report_file, " was changed after ", idx_file, " created." ..
             " Please rerun luacov-console <dir> to recreate the index.")
     end
 
@@ -172,7 +176,7 @@ local function print_summary(no_colored, patterns)
 end
 
 local parser = argparse("luacov-console",
-                        "Combine luacov with your development cycle and CI")
+    "Combine luacov with your development cycle and CI")
 parser:argument("workdir", "Specific the source directory", '.')
 parser:option("--version", "Print version"):args(0)
 parser:option("--no-colored", "Don't print with color."):args(0)
@@ -182,7 +186,7 @@ parser:option("-s --summary", "Show coverage summary."):args(0)
 local args = parser:parse()
 
 if args.summary then
-    print_summary(args.no_colored, args.list or { ".*" })
+    print_summary(args.no_colored, args.list)
 elseif args.list then
     print_results(args.list, args.no_colored)
 elseif args.version then

--- a/src/luacov-console.lua
+++ b/src/luacov-console.lua
@@ -27,6 +27,14 @@ local function colored_print(color, text)
     print(start_color .. text .. end_color)
 end
 
+local function colored_print_if_pattern(color, text, patterns)
+    for _, pattern in ipairs(patterns) do
+        if text:match(pattern) then
+            colored_print(color, text)
+        end
+    end
+end
+
 local function print_error(...)
     io.stderr:write(...)
     os.exit(1)
@@ -108,7 +116,7 @@ local function print_results(patterns, no_colored)
     file:close()
 end
 
-local function print_summary(no_colored)
+local function print_summary(no_colored, patterns)
     local data_file = configuration.reportfile
     local file, err = io.open(data_file)
     if not file then
@@ -135,7 +143,7 @@ local function print_summary(no_colored)
         }
         for i, level in ipairs(levels) do
             if coverage <= level then
-                colored_print(colors[i], line)
+                colored_print_if_pattern(colors[i], line, patterns)
                 return
             end
         end
@@ -173,10 +181,10 @@ parser:option("-s --summary", "Show coverage summary."):args(0)
 
 local args = parser:parse()
 
-if args.list then
+if args.summary then
+    print_summary(args.no_colored, args.list or { ".*" })
+elseif args.list then
     print_results(args.list, args.no_colored)
-elseif args.summary then
-    print_summary(args.no_colored)
 elseif args.version then
     print(VERSION)
 else


### PR DESCRIPTION
hope you're open for minor improvements?

this adds support for patterns via -l flag to summary report (-s).
